### PR TITLE
docs: fix link to Examples section on index page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ hero:
       link: /api
     - theme: alt
       text: Examples
-      link: /example-scaling-recipes
+      link: /examples-scaling-recipes
 
 features:
   - title: Cooklang + Typescript


### PR DESCRIPTION
The current link leads to 404

https://cooklang-parser.tmlmt.com/example-big-recipe.html