### PR TITLE
ci(release): publish release with pre-release tag for pre-release version numbers

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -267,7 +267,7 @@ async function main() {
   log.info("Creating GitHub release...");
   // Re-extract the changelog, which may have been edited in the review step
   releaseNotes = extractReleaseNotes();
-  await run("gh", [
+  const releaseArgs = [
     "release",
     "create",
     tag,
@@ -275,7 +275,15 @@ async function main() {
     tag,
     "--notes",
     releaseNotes,
-  ]);
+  ];
+
+  // Add --prerelease flag if version contains a dash (alpha, beta, rc, etc.)
+  if (version.includes("-")) {
+    releaseArgs.push("--prerelease");
+    log.info("Pre-release detected. Adding --prerelease flag.");
+  }
+
+  await run("gh", releaseArgs);
 
   if (DRY_RUN) {
     await execa("git", ["checkout", "package.json", "CHANGELOG.md"], {


### PR DESCRIPTION
# Description

Automatically mark GitHub releases as pre-releases when the version contains a dash (indicating alpha, beta, rc, etc.). This enhances the release process by properly categorizing pre-release versions in GitHub.

The script now:

- Detects if the version string includes a dash
- Adds the `--prerelease` flag to the GitHub release command when appropriate
- Logs a message when a pre-release is detected

Fixes #(issue number for pre-release tagging)

## Type of change

- [x] New feature (non-breaking change which adds functionality)