### PR TITLE
style(types): remove unnecessary layer 'groupQuantity' and rename alternativeQuantities into 'quantities'

### DIFF
--- a/playground/app/components/recipe/IngredientItem.vue
+++ b/playground/app/components/recipe/IngredientItem.vue
@@ -209,11 +209,8 @@ const displayMode = computed<DisplayMode>(() => {
           :key="idx"
         >
           <template v-if="idx > 0">, or </template>
-          <template v-if="alt.alternativeQuantities?.length">
-            <template
-              v-for="(altQty, qtyIdx) in alt.alternativeQuantities"
-              :key="qtyIdx"
-            >
+          <template v-if="alt.quantities?.length">
+            <template v-for="(altQty, qtyIdx) in alt.quantities" :key="qtyIdx">
               <template v-if="qtyIdx > 0"> + </template>
               <RecipeQuantityWithEquivalents
                 :quantity="altQty"
@@ -308,9 +305,9 @@ const displayMode = computed<DisplayMode>(() => {
                 :key="altIdx"
               >
                 <template v-if="altIdx > 0">, </template>
-                <template v-if="alt.alternativeQuantities?.length">
+                <template v-if="alt.quantities?.length">
                   <template
-                    v-for="(altQty, qtyIdx) in alt.alternativeQuantities"
+                    v-for="(altQty, qtyIdx) in alt.quantities"
                     :key="qtyIdx"
                   >
                     <template v-if="qtyIdx > 0"> + </template>

--- a/playground/app/components/recipe/IngredientItem.vue
+++ b/playground/app/components/recipe/IngredientItem.vue
@@ -35,12 +35,12 @@ function isAndGroup(
 }
 
 /**
- * Type guard: checks if entry is a simple group with groupQuantity
+ * Type guard: checks if entry is a simple group with a single quantity
  */
 function isSimpleGroup(
   entry: IngredientQuantityEntry,
 ): entry is IngredientQuantityGroup {
-  return "groupQuantity" in entry;
+  return "quantity" in entry;
 }
 
 /**
@@ -126,9 +126,7 @@ const displayMode = computed<DisplayMode>(() => {
     <template v-if="displayMode.type === 'single'">
       {{ optionalPrefix }}
       <span>
-        <RecipeQuantityWithEquivalents
-          :quantity="displayMode.entry.groupQuantity"
-        />
+        <RecipeQuantityWithEquivalents :quantity="displayMode.entry.quantity" />
       </span>
       {{ " " }}
       <span class="font-bold">{{ ingredient.name }}</span>
@@ -144,11 +142,11 @@ const displayMode = computed<DisplayMode>(() => {
     <template v-else-if="displayMode.type === 'two-plain'">
       <span>
         <RecipeQuantityWithEquivalents
-          :quantity="displayMode.entries[0].groupQuantity"
+          :quantity="displayMode.entries[0].quantity"
         />
         and
         <RecipeQuantityWithEquivalents
-          :quantity="displayMode.entries[1].groupQuantity"
+          :quantity="displayMode.entries[1].quantity"
         />
       </span>
       {{ " " }}
@@ -169,7 +167,11 @@ const displayMode = computed<DisplayMode>(() => {
         <span>
           <template v-for="(qty, idx) in displayMode.entry.entries" :key="idx">
             <template v-if="idx > 0"> + </template>
-            <RecipeQuantityWithEquivalents :quantity="qty" />
+            <RecipeQuantityWithEquivalents
+              :quantity="qty.quantity"
+              :unit="qty.unit"
+              :equivalents="qty.equivalents"
+            />
           </template>
           <template v-if="displayMode.entry.equivalents?.length">
             (≈
@@ -190,7 +192,7 @@ const displayMode = computed<DisplayMode>(() => {
       <template v-else-if="isSimpleGroup(displayMode.entry)">
         <span>
           <RecipeQuantityWithEquivalents
-            :quantity="displayMode.entry.groupQuantity"
+            :quantity="displayMode.entry.quantity"
           />
         </span>
       </template>
@@ -213,7 +215,9 @@ const displayMode = computed<DisplayMode>(() => {
             <template v-for="(altQty, qtyIdx) in alt.quantities" :key="qtyIdx">
               <template v-if="qtyIdx > 0"> + </template>
               <RecipeQuantityWithEquivalents
-                :quantity="altQty"
+                :quantity="altQty.quantity"
+                :unit="altQty.unit"
+                :equivalents="altQty.equivalents"
                 wrapper-start="["
                 wrapper-end="]"
               />
@@ -231,7 +235,11 @@ const displayMode = computed<DisplayMode>(() => {
       <span>
         <template v-for="(qty, idx) in displayMode.entry.entries" :key="idx">
           <template v-if="idx > 0"> + </template>
-          <RecipeQuantityWithEquivalents :quantity="qty" />
+          <RecipeQuantityWithEquivalents
+            :quantity="qty.quantity"
+            :unit="qty.unit"
+            :equivalents="qty.equivalents"
+          />
         </template>
         <template v-if="displayMode.entry.equivalents?.length">
           {{ " " }}(≈
@@ -268,7 +276,11 @@ const displayMode = computed<DisplayMode>(() => {
             <span>
               <template v-for="(qty, qtyIdx) in entry.entries" :key="qtyIdx">
                 <template v-if="qtyIdx > 0"> + </template>
-                <RecipeQuantityWithEquivalents :quantity="qty" />
+                <RecipeQuantityWithEquivalents
+                  :quantity="qty.quantity"
+                  :unit="qty.unit"
+                  :equivalents="qty.equivalents"
+                />
               </template>
               <template v-if="entry.equivalents?.length">
                 {{ " " }}(≈
@@ -285,7 +297,7 @@ const displayMode = computed<DisplayMode>(() => {
           <!-- Render simple group entry -->
           <template v-else-if="isSimpleGroup(entry)">
             <span>
-              <RecipeQuantityWithEquivalents :quantity="entry.groupQuantity" />
+              <RecipeQuantityWithEquivalents :quantity="entry.quantity" />
             </span>
           </template>
 
@@ -311,7 +323,11 @@ const displayMode = computed<DisplayMode>(() => {
                     :key="qtyIdx"
                   >
                     <template v-if="qtyIdx > 0"> + </template>
-                    <RecipeQuantityWithEquivalents :quantity="altQty" />
+                    <RecipeQuantityWithEquivalents
+                      :quantity="altQty.quantity"
+                      :unit="altQty.unit"
+                      :equivalents="altQty.equivalents"
+                    />
                   </template>
                   {{ " " }}
                 </template>

--- a/playground/app/components/recipe/QuantityWithEquivalents.vue
+++ b/playground/app/components/recipe/QuantityWithEquivalents.vue
@@ -1,29 +1,33 @@
 <script setup lang="ts">
-import type { QuantityWithPlainUnit } from "cooklang-parser";
+import type { FixedValue, Range, QuantityWithPlainUnit } from "cooklang-parser";
 
 const props = withDefaults(
   defineProps<{
-    quantity: QuantityWithPlainUnit;
+    quantity: FixedValue | Range;
+    unit?: string;
+    equivalents?: QuantityWithPlainUnit[];
     wrapperStart?: string;
     wrapperEnd?: string;
   }>(),
   {
+    unit: undefined,
+    equivalents: undefined,
     wrapperStart: "(",
     wrapperEnd: ")",
   },
 );
 
 const hasEquivalents = computed(
-  () => props.quantity.equivalents && props.quantity.equivalents.length > 0,
+  () => props.equivalents && props.equivalents.length > 0,
 );
 </script>
 
 <template>
   <span class="quantity-with-equivalents">
-    <RecipeSingleQuantity :quantity="quantity.quantity" :unit="quantity.unit" />
+    <RecipeSingleQuantity :quantity="quantity" :unit="unit" />
     <template v-if="hasEquivalents"
       >{{ " " }}{{ wrapperStart
-      }}<template v-for="(equiv, index) in quantity.equivalents" :key="index"
+      }}<template v-for="(equiv, index) in equivalents" :key="index"
         ><template v-if="index > 0">, </template
         ><RecipeSingleQuantity
           :quantity="equiv.quantity"

--- a/playground/app/components/recipe/StepContent.vue
+++ b/playground/app/components/recipe/StepContent.vue
@@ -15,19 +15,15 @@ const props = defineProps<{
 }>();
 
 /**
- * Convert an IngredientItemQuantity to a QuantityWithPlainUnit for the component
+ * Convert IngredientItemQuantity equivalents to QuantityWithPlainUnit array
  */
-function toQuantityWithPlainUnit(
+function toPlainEquivalents(
   itemQty: IngredientItemQuantity,
-): QuantityWithPlainUnit {
-  return {
-    quantity: itemQty.quantity,
-    unit: itemQty.unit?.name,
-    equivalents: itemQty.equivalents?.map((eq) => ({
-      quantity: eq.quantity,
-      unit: eq.unit?.name,
-    })),
-  };
+): QuantityWithPlainUnit[] | undefined {
+  return itemQty.equivalents?.map((eq) => ({
+    quantity: eq.quantity,
+    unit: eq.unit?.name,
+  }));
 }
 
 /**
@@ -79,11 +75,9 @@ function getTimer(index: number): Timer | undefined {
           <!-- Primary ingredient with quantity -->
           <template v-if="getPrimaryAlternative(item)?.itemQuantity">
             <RecipeQuantityWithEquivalents
-              :quantity="
-                toQuantityWithPlainUnit(
-                  getPrimaryAlternative(item)!.itemQuantity!,
-                )
-              "
+              :quantity="getPrimaryAlternative(item)!.itemQuantity!.quantity"
+              :unit="getPrimaryAlternative(item)!.itemQuantity!.unit?.name"
+              :equivalents="toPlainEquivalents(getPrimaryAlternative(item)!.itemQuantity!)"
             />
             {{ " " }}
           </template>
@@ -100,7 +94,9 @@ function getTimer(index: number): Timer | undefined {
               <template v-if="altIdx > 0">, or </template>
               <template v-if="alt.itemQuantity">
                 <RecipeQuantityWithEquivalents
-                  :quantity="toQuantityWithPlainUnit(alt.itemQuantity)"
+                  :quantity="alt.itemQuantity.quantity"
+                  :unit="alt.itemQuantity.unit?.name"
+                  :equivalents="toPlainEquivalents(alt.itemQuantity)"
                   wrapper-start="["
                   wrapper-end="]"
                 />

--- a/src/classes/recipe.ts
+++ b/src/classes/recipe.ts
@@ -615,7 +615,7 @@ export class Recipe {
                 index: otherAlt.index,
               };
               if (otherAlt.itemQuantity) {
-                // Build the alternativeQuantities with plain units
+                // Build the alternative quantities with plain units
                 const altQty: QuantityWithPlainUnit = {
                   quantity: otherAlt.itemQuantity.quantity,
                 };
@@ -628,7 +628,7 @@ export class Recipe {
                     (eq) => toPlainUnit(eq) as QuantityWithPlainUnit,
                   );
                 }
-                newRef.alternativeQuantities = [altQty];
+                newRef.quantities = [altQty];
               }
               alternativeRefs.push(newRef);
             }
@@ -643,7 +643,7 @@ export class Recipe {
               const otherAlt = groupAlternatives[j] as IngredientAlternative;
               /* v8 ignore else -- @preserve */
               if (otherAlt.itemQuantity) {
-                // Build the alternativeQuantities with plain units
+                // Build the alternative quantities with plain units
                 const altQty: QuantityWithPlainUnit = {
                   quantity: otherAlt.itemQuantity.quantity,
                 };
@@ -657,7 +657,7 @@ export class Recipe {
                 }
                 alternativeRefs.push({
                   index: otherAlt.index,
-                  alternativeQuantities: [altQty],
+                  quantities: [altQty],
                 });
               }
             }
@@ -705,11 +705,8 @@ export class Recipe {
                 group.alternativeQuantities.set(ref.index, []);
               }
 
-              if (
-                ref.alternativeQuantities &&
-                ref.alternativeQuantities.length > 0
-              ) {
-                for (const altQty of ref.alternativeQuantities) {
+              if (ref.quantities && ref.quantities.length > 0) {
+                for (const altQty of ref.quantities) {
                   if (altQty.equivalents && altQty.equivalents.length > 0) {
                     const entries: QuantityWithExtendedUnit[] = [
                       toExtendedUnit({
@@ -768,7 +765,7 @@ export class Recipe {
               // Convert to array of QuantityWithPlainUnit
               const flattenedAlt = flattenPlainUnitGroup(summedAltQuantity);
               // Extract quantities from the flattened result
-              ref.alternativeQuantities = flattenedAlt.flatMap((item) => {
+              ref.quantities = flattenedAlt.flatMap((item) => {
                 if ("groupQuantity" in item) {
                   return [item.groupQuantity];
                 } else {

--- a/src/classes/recipe.ts
+++ b/src/classes/recipe.ts
@@ -766,8 +766,8 @@ export class Recipe {
               const flattenedAlt = flattenPlainUnitGroup(summedAltQuantity);
               // Extract quantities from the flattened result
               ref.quantities = flattenedAlt.flatMap((item) => {
-                if ("groupQuantity" in item) {
-                  return [item.groupQuantity];
+                if ("quantity" in item) {
+                  return [item];
                 } else {
                   // AND group: return entries (could also include equivalents if needed)
                   return item.entries;

--- a/src/quantities/mutations.ts
+++ b/src/quantities/mutations.ts
@@ -275,7 +275,7 @@ export function deNormalizeQuantity(
 export const flattenPlainUnitGroup = (
   summed: QuantityWithPlainUnit | MaybeNestedGroup<QuantityWithPlainUnit>,
 ): (
-  | { groupQuantity: QuantityWithPlainUnit }
+  | QuantityWithPlainUnit
   | {
       type: "and";
       entries: QuantityWithPlainUnit[];
@@ -319,7 +319,7 @@ export const flattenPlainUnitGroup = (
         ];
       } else {
         // No equivalents: flatten to separate entries (shouldn't happen in this branch, but handle it)
-        return andEntries.map((entry) => ({ groupQuantity: entry }));
+        return andEntries;
       }
     }
 
@@ -336,14 +336,12 @@ export const flattenPlainUnitGroup = (
       if (simpleEntries.length > 1) {
         result.equivalents = simpleEntries.slice(1);
       }
-      return [{ groupQuantity: result }];
+      return [result];
     }
     // Fallback: use first entry regardless
     else {
       const first = entries[0] as QuantityWithPlainUnit;
-      return [
-        { groupQuantity: { quantity: first.quantity, unit: first.unit } },
-      ];
+      return [{ quantity: first.quantity, unit: first.unit }];
     }
   } else if (isGroup(summed)) {
     // AND group: check if entries have OR groups (equivalents that can be extracted)
@@ -378,7 +376,7 @@ export const flattenPlainUnitGroup = (
     // If there are equivalents, return an AND group with the summed equivalents (carrots case)
     if (equivalentsList.length === 0) {
       // No equivalents: flatten to separate entries
-      return andEntries.map((entry) => ({ groupQuantity: entry }));
+      return andEntries;
     }
 
     const result: {
@@ -394,8 +392,6 @@ export const flattenPlainUnitGroup = (
     return [result];
   } else {
     // Simple QuantityWithPlainUnit
-    return [
-      { groupQuantity: { quantity: summed.quantity, unit: summed.unit } },
-    ];
+    return [{ quantity: summed.quantity, unit: summed.unit }];
   }
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -236,18 +236,12 @@ export interface AlternativeIngredientRef {
  * When units are incompatible, separate IngredientQuantityGroup entries are created instead of merging.
  * @category Types
  */
-export interface IngredientQuantityGroup {
+export interface IngredientQuantityGroup extends QuantityWithPlainUnit {
   /**
    * References to alternative ingredients for this quantity group.
    * If undefined, this group has no alternatives.
    */
   alternatives?: AlternativeIngredientRef[];
-  /**
-   * The summed quantity for this group, potentially with equivalents.
-   * OR groups from addEquivalentsAndSimplify are converted back to QuantityWithPlainUnit
-   * (first entry as main, rest as equivalents).
-   */
-  groupQuantity: QuantityWithPlainUnit;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -227,7 +227,7 @@ export interface AlternativeIngredientRef {
   /** The index of the alternative ingredient within the {@link Recipe.ingredients} array. */
   index: number;
   /** The quantities of the alternative ingredient. Multiple entries when units are incompatible. */
-  alternativeQuantities?: QuantityWithPlainUnit[];
+  quantities?: QuantityWithPlainUnit[];
 }
 
 /**

--- a/test/__snapshots__/recipe_parsing.test.ts.snap
+++ b/test/__snapshots__/recipe_parsing.test.ts.snap
@@ -187,16 +187,14 @@ Recipe {
       "name": "lasagne noodles",
       "quantities": [
         {
-          "groupQuantity": {
-            "quantity": {
-              "type": "fixed",
-              "value": {
-                "decimal": 9,
-                "type": "decimal",
-              },
+          "quantity": {
+            "type": "fixed",
+            "value": {
+              "decimal": 9,
+              "type": "decimal",
             },
-            "unit": undefined,
           },
+          "unit": undefined,
         },
       ],
       "usedAsPrimary": true,
@@ -205,16 +203,14 @@ Recipe {
       "name": "bulk Italian sausage",
       "quantities": [
         {
-          "groupQuantity": {
-            "quantity": {
-              "type": "fixed",
-              "value": {
-                "decimal": 1.2,
-                "type": "decimal",
-              },
+          "quantity": {
+            "type": "fixed",
+            "value": {
+              "decimal": 1.2,
+              "type": "decimal",
             },
-            "unit": "lb",
           },
+          "unit": "lb",
         },
       ],
       "usedAsPrimary": true,
@@ -223,17 +219,15 @@ Recipe {
       "name": "ground beef",
       "quantities": [
         {
-          "groupQuantity": {
-            "quantity": {
-              "type": "fixed",
-              "value": {
-                "den": 4,
-                "num": 3,
-                "type": "fraction",
-              },
+          "quantity": {
+            "type": "fixed",
+            "value": {
+              "den": 4,
+              "num": 3,
+              "type": "fraction",
             },
-            "unit": "lb",
           },
+          "unit": "lb",
         },
       ],
       "usedAsPrimary": true,
@@ -243,16 +237,14 @@ Recipe {
       "preparation": "medium, diced",
       "quantities": [
         {
-          "groupQuantity": {
-            "quantity": {
-              "type": "fixed",
-              "value": {
-                "decimal": 1,
-                "type": "decimal",
-              },
+          "quantity": {
+            "type": "fixed",
+            "value": {
+              "decimal": 1,
+              "type": "decimal",
             },
-            "unit": undefined,
           },
+          "unit": undefined,
         },
       ],
       "usedAsPrimary": true,
@@ -261,16 +253,14 @@ Recipe {
       "name": "garlic",
       "quantities": [
         {
-          "groupQuantity": {
-            "quantity": {
-              "type": "fixed",
-              "value": {
-                "decimal": 3,
-                "type": "decimal",
-              },
+          "quantity": {
+            "type": "fixed",
+            "value": {
+              "decimal": 3,
+              "type": "decimal",
             },
-            "unit": "cloves",
           },
+          "unit": "cloves",
         },
       ],
       "usedAsPrimary": true,
@@ -279,16 +269,14 @@ Recipe {
       "name": "crushed tomatoes",
       "quantities": [
         {
-          "groupQuantity": {
-            "quantity": {
-              "type": "fixed",
-              "value": {
-                "decimal": 2,
-                "type": "decimal",
-              },
+          "quantity": {
+            "type": "fixed",
+            "value": {
+              "decimal": 2,
+              "type": "decimal",
             },
-            "unit": "cans",
           },
+          "unit": "cans",
         },
       ],
       "usedAsPrimary": true,
@@ -297,16 +285,14 @@ Recipe {
       "name": "tomato paste",
       "quantities": [
         {
-          "groupQuantity": {
-            "quantity": {
-              "type": "fixed",
-              "value": {
-                "decimal": 2,
-                "type": "decimal",
-              },
+          "quantity": {
+            "type": "fixed",
+            "value": {
+              "decimal": 2,
+              "type": "decimal",
             },
-            "unit": "cans",
           },
+          "unit": "cans",
         },
       ],
       "usedAsPrimary": true,
@@ -315,17 +301,15 @@ Recipe {
       "name": "water",
       "quantities": [
         {
-          "groupQuantity": {
-            "quantity": {
-              "type": "fixed",
-              "value": {
-                "den": 3,
-                "num": 2,
-                "type": "fraction",
-              },
+          "quantity": {
+            "type": "fixed",
+            "value": {
+              "den": 3,
+              "num": 2,
+              "type": "fraction",
             },
-            "unit": "cup",
           },
+          "unit": "cup",
         },
       ],
       "usedAsPrimary": true,
@@ -334,16 +318,14 @@ Recipe {
       "name": "sugar",
       "quantities": [
         {
-          "groupQuantity": {
-            "quantity": {
-              "type": "fixed",
-              "value": {
-                "decimal": 2,
-                "type": "decimal",
-              },
+          "quantity": {
+            "type": "fixed",
+            "value": {
+              "decimal": 2,
+              "type": "decimal",
             },
-            "unit": "tbsp",
           },
+          "unit": "tbsp",
         },
       ],
       "usedAsPrimary": true,
@@ -353,16 +335,14 @@ Recipe {
       "preparation": "minced, divided",
       "quantities": [
         {
-          "groupQuantity": {
-            "quantity": {
-              "type": "fixed",
-              "value": {
-                "decimal": 0.104,
-                "type": "decimal",
-              },
+          "quantity": {
+            "type": "fixed",
+            "value": {
+              "decimal": 0.104,
+              "type": "decimal",
             },
-            "unit": "l",
           },
+          "unit": "l",
         },
       ],
       "usedAsPrimary": true,
@@ -371,16 +351,14 @@ Recipe {
       "name": "dried basil",
       "quantities": [
         {
-          "groupQuantity": {
-            "quantity": {
-              "type": "fixed",
-              "value": {
-                "decimal": 2,
-                "type": "decimal",
-              },
+          "quantity": {
+            "type": "fixed",
+            "value": {
+              "decimal": 2,
+              "type": "decimal",
             },
-            "unit": "tsp",
           },
+          "unit": "tsp",
         },
       ],
       "usedAsPrimary": true,
@@ -389,17 +367,15 @@ Recipe {
       "name": "fennel seed",
       "quantities": [
         {
-          "groupQuantity": {
-            "quantity": {
-              "type": "fixed",
-              "value": {
-                "den": 4,
-                "num": 3,
-                "type": "fraction",
-              },
+          "quantity": {
+            "type": "fixed",
+            "value": {
+              "den": 4,
+              "num": 3,
+              "type": "fraction",
             },
-            "unit": "tsp",
           },
+          "unit": "tsp",
         },
       ],
       "usedAsPrimary": true,
@@ -408,17 +384,15 @@ Recipe {
       "name": "salt",
       "quantities": [
         {
-          "groupQuantity": {
-            "quantity": {
-              "type": "fixed",
-              "value": {
-                "den": 4,
-                "num": 3,
-                "type": "fraction",
-              },
+          "quantity": {
+            "type": "fixed",
+            "value": {
+              "den": 4,
+              "num": 3,
+              "type": "fraction",
             },
-            "unit": "tsp",
           },
+          "unit": "tsp",
         },
       ],
       "usedAsPrimary": true,
@@ -428,17 +402,15 @@ Recipe {
       "preparation": "coarsely ground",
       "quantities": [
         {
-          "groupQuantity": {
-            "quantity": {
-              "type": "fixed",
-              "value": {
-                "den": 4,
-                "num": 1,
-                "type": "fraction",
-              },
+          "quantity": {
+            "type": "fixed",
+            "value": {
+              "den": 4,
+              "num": 1,
+              "type": "fraction",
             },
-            "unit": "tsp",
           },
+          "unit": "tsp",
         },
       ],
       "usedAsPrimary": true,
@@ -448,16 +420,14 @@ Recipe {
       "preparation": "large, lightly beaten",
       "quantities": [
         {
-          "groupQuantity": {
-            "quantity": {
-              "type": "fixed",
-              "value": {
-                "decimal": 1,
-                "type": "decimal",
-              },
+          "quantity": {
+            "type": "fixed",
+            "value": {
+              "decimal": 1,
+              "type": "decimal",
             },
-            "unit": undefined,
           },
+          "unit": undefined,
         },
       ],
       "usedAsPrimary": true,
@@ -466,16 +436,14 @@ Recipe {
       "name": "ricotta cheese",
       "quantities": [
         {
-          "groupQuantity": {
-            "quantity": {
-              "type": "fixed",
-              "value": {
-                "decimal": 1,
-                "type": "decimal",
-              },
+          "quantity": {
+            "type": "fixed",
+            "value": {
+              "decimal": 1,
+              "type": "decimal",
             },
-            "unit": "carton",
           },
+          "unit": "carton",
         },
       ],
       "usedAsPrimary": true,
@@ -485,16 +453,14 @@ Recipe {
       "preparation": "shredded",
       "quantities": [
         {
-          "groupQuantity": {
-            "quantity": {
-              "type": "fixed",
-              "value": {
-                "decimal": 4,
-                "type": "decimal",
-              },
+          "quantity": {
+            "type": "fixed",
+            "value": {
+              "decimal": 4,
+              "type": "decimal",
             },
-            "unit": "cups",
           },
+          "unit": "cups",
         },
       ],
       "usedAsPrimary": true,
@@ -504,17 +470,15 @@ Recipe {
       "preparation": "grated",
       "quantities": [
         {
-          "groupQuantity": {
-            "quantity": {
-              "type": "fixed",
-              "value": {
-                "den": 4,
-                "num": 3,
-                "type": "fraction",
-              },
+          "quantity": {
+            "type": "fixed",
+            "value": {
+              "den": 4,
+              "num": 3,
+              "type": "fraction",
             },
-            "unit": "cup",
           },
+          "unit": "cup",
         },
       ],
       "usedAsPrimary": true,

--- a/test/parser_helpers.test.ts
+++ b/test/parser_helpers.test.ts
@@ -396,9 +396,7 @@ describe("findAndUpsertIngredient", () => {
       name: "eggs",
       quantities: [
         {
-          groupQuantity: {
-            quantity: { type: "fixed", value: { type: "decimal", decimal: 1 } },
-          },
+          quantity: { type: "fixed", value: { type: "decimal", decimal: 1 } },
         },
       ],
     };
@@ -414,11 +412,9 @@ describe("findAndUpsertIngredient", () => {
         name: "eggs",
         quantities: [
           {
-            groupQuantity: {
-              quantity: {
-                type: "fixed",
-                value: { type: "decimal", decimal: 1 },
-              },
+            quantity: {
+              type: "fixed",
+              value: { type: "decimal", decimal: 1 },
             },
           },
         ],
@@ -428,9 +424,7 @@ describe("findAndUpsertIngredient", () => {
       name: "eggs",
       quantities: [
         {
-          groupQuantity: {
-            quantity: { type: "fixed", value: { type: "decimal", decimal: 2 } },
-          },
+          quantity: { type: "fixed", value: { type: "decimal", decimal: 2 } },
         },
       ],
     };
@@ -439,9 +433,7 @@ describe("findAndUpsertIngredient", () => {
     );
     expect(ingredients[0]!.quantities).toEqual([
       {
-        groupQuantity: {
-          quantity: { type: "fixed", value: { type: "decimal", decimal: 1 } },
-        },
+        quantity: { type: "fixed", value: { type: "decimal", decimal: 1 } },
       },
     ]);
 
@@ -459,9 +451,7 @@ describe("findAndUpsertIngredient", () => {
         name: "eggs",
         quantities: [
           {
-            groupQuantity: {
-              quantity: { type: "fixed", value: { type: "text", text: "one" } },
-            },
+            quantity: { type: "fixed", value: { type: "text", text: "one" } },
           },
         ],
       },
@@ -470,9 +460,7 @@ describe("findAndUpsertIngredient", () => {
       name: "eggs",
       quantities: [
         {
-          groupQuantity: {
-            quantity: { type: "fixed", value: { type: "decimal", decimal: 1 } },
-          },
+          quantity: { type: "fixed", value: { type: "decimal", decimal: 1 } },
         },
       ],
     };
@@ -488,11 +476,9 @@ describe("findAndUpsertIngredient", () => {
         name: "eggs",
         quantities: [
           {
-            groupQuantity: {
-              quantity: {
-                type: "fixed",
-                value: { type: "decimal", decimal: 1 },
-              },
+            quantity: {
+              type: "fixed",
+              value: { type: "decimal", decimal: 1 },
             },
           },
         ],
@@ -502,13 +488,11 @@ describe("findAndUpsertIngredient", () => {
       name: "unreferenced-ingredient",
       quantities: [
         {
-          groupQuantity: {
-            quantity: {
-              type: "fixed",
-              value: { type: "decimal", decimal: 100 },
-            },
-            unit: "g",
+          quantity: {
+            type: "fixed",
+            value: { type: "decimal", decimal: 100 },
           },
+          unit: "g",
         },
       ],
       flags: [],
@@ -526,11 +510,9 @@ describe("findAndUpsertIngredient", () => {
         name: "eggs",
         quantities: [
           {
-            groupQuantity: {
-              quantity: {
-                type: "fixed",
-                value: { type: "decimal", decimal: 1 },
-              },
+            quantity: {
+              type: "fixed",
+              value: { type: "decimal", decimal: 1 },
             },
           },
         ],
@@ -541,9 +523,7 @@ describe("findAndUpsertIngredient", () => {
       name: "eggs",
       quantities: [
         {
-          groupQuantity: {
-            quantity: { type: "fixed", value: { type: "decimal", decimal: 2 } },
-          },
+          quantity: { type: "fixed", value: { type: "decimal", decimal: 2 } },
         },
       ],
     };

--- a/test/quantities_mutations.test.ts
+++ b/test/quantities_mutations.test.ts
@@ -796,10 +796,8 @@ describe("flattenPlainUnitGroup", () => {
     };
     expect(flattenPlainUnitGroup(input)).toEqual([
       {
-        groupQuantity: {
-          quantity: { type: "fixed", value: { type: "decimal", decimal: 5 } },
-          unit: "g",
-        },
+        quantity: { type: "fixed", value: { type: "decimal", decimal: 5 } },
+        unit: "g",
       },
     ]);
   });
@@ -819,19 +817,17 @@ describe("flattenPlainUnitGroup", () => {
     };
     expect(flattenPlainUnitGroup(input)).toEqual([
       {
-        groupQuantity: {
-          quantity: { type: "fixed", value: { type: "decimal", decimal: 1 } },
-          unit: "cup",
-          equivalents: [
-            {
-              quantity: {
-                type: "fixed",
-                value: { type: "decimal", decimal: 250 },
-              },
-              unit: "mL",
+        quantity: { type: "fixed", value: { type: "decimal", decimal: 1 } },
+        unit: "cup",
+        equivalents: [
+          {
+            quantity: {
+              type: "fixed",
+              value: { type: "decimal", decimal: 250 },
             },
-          ],
-        },
+            unit: "mL",
+          },
+        ],
       },
     ]);
   });
@@ -851,16 +847,12 @@ describe("flattenPlainUnitGroup", () => {
     };
     expect(flattenPlainUnitGroup(input)).toEqual([
       {
-        groupQuantity: {
-          quantity: { type: "fixed", value: { type: "decimal", decimal: 2 } },
-          unit: "egg",
-        },
+        quantity: { type: "fixed", value: { type: "decimal", decimal: 2 } },
+        unit: "egg",
       },
       {
-        groupQuantity: {
-          quantity: { type: "fixed", value: { type: "decimal", decimal: 100 } },
-          unit: "g",
-        },
+        quantity: { type: "fixed", value: { type: "decimal", decimal: 100 } },
+        unit: "g",
       },
     ]);
   });
@@ -876,10 +868,8 @@ describe("flattenPlainUnitGroup", () => {
     };
     expect(flattenPlainUnitGroup(input)).toEqual([
       {
-        groupQuantity: {
-          quantity: { type: "fixed", value: { type: "decimal", decimal: 1 } },
-          unit: "cup",
-        },
+        quantity: { type: "fixed", value: { type: "decimal", decimal: 1 } },
+        unit: "cup",
       },
     ]);
   });

--- a/test/recipe_parsing.test.ts
+++ b/test/recipe_parsing.test.ts
@@ -1217,7 +1217,7 @@ Another step.
               alternatives: [
                 {
                   index: 1,
-                  alternativeQuantities: [
+                  quantities: [
                     {
                       quantity: {
                         type: "fixed",
@@ -1259,7 +1259,7 @@ Another step.
             alternatives: [
               {
                 index: 1,
-                alternativeQuantities: [
+                quantities: [
                   {
                     quantity: {
                       type: "fixed",
@@ -1271,7 +1271,7 @@ Another step.
               },
               {
                 index: 2,
-                alternativeQuantities: [
+                quantities: [
                   {
                     quantity: {
                       type: "fixed",
@@ -1398,7 +1398,7 @@ Another step.
             alternatives: [
               {
                 index: 1,
-                alternativeQuantities: [
+                quantities: [
                   {
                     quantity: {
                       type: "fixed",
@@ -1410,7 +1410,7 @@ Another step.
               },
               {
                 index: 2,
-                alternativeQuantities: [
+                quantities: [
                   {
                     quantity: {
                       type: "fixed",
@@ -1545,7 +1545,7 @@ Another step.
             alternatives: [
               {
                 index: 1,
-                alternativeQuantities: [
+                quantities: [
                   {
                     quantity: {
                       type: "fixed",
@@ -1568,7 +1568,7 @@ Another step.
             alternatives: [
               {
                 index: 2,
-                alternativeQuantities: [
+                quantities: [
                   {
                     quantity: {
                       type: "fixed",
@@ -1607,7 +1607,7 @@ Another step.
             alternatives: [
               {
                 index: 1,
-                alternativeQuantities: [
+                quantities: [
                   {
                     quantity: {
                       type: "fixed",
@@ -1630,7 +1630,7 @@ Another step.
             alternatives: [
               {
                 index: 2,
-                alternativeQuantities: [
+                quantities: [
                   {
                     quantity: {
                       type: "fixed",
@@ -1642,7 +1642,7 @@ Another step.
               },
               {
                 index: 1,
-                alternativeQuantities: [
+                quantities: [
                   {
                     quantity: {
                       type: "fixed",
@@ -1699,7 +1699,7 @@ Another step.
             alternatives: [
               {
                 index: 1,
-                alternativeQuantities: [
+                quantities: [
                   {
                     quantity: {
                       type: "fixed",
@@ -1748,7 +1748,7 @@ Another step.
             alternatives: [
               {
                 index: 1,
-                alternativeQuantities: [
+                quantities: [
                   {
                     quantity: {
                       type: "fixed",
@@ -1760,7 +1760,7 @@ Another step.
               },
               {
                 index: 2,
-                alternativeQuantities: [
+                quantities: [
                   {
                     quantity: {
                       type: "fixed",
@@ -1881,7 +1881,7 @@ Another step.
             alternatives: [
               {
                 index: 1,
-                alternativeQuantities: [
+                quantities: [
                   {
                     quantity: {
                       type: "fixed",
@@ -1994,7 +1994,7 @@ Another step.
             alternatives: [
               {
                 index: 1,
-                alternativeQuantities: [
+                quantities: [
                   {
                     quantity: {
                       type: "fixed",
@@ -2128,7 +2128,7 @@ Another step.
             alternatives: [
               {
                 index: 1,
-                alternativeQuantities: [
+                quantities: [
                   {
                     quantity: {
                       type: "fixed",
@@ -2178,7 +2178,7 @@ Another step.
             alternatives: [
               {
                 index: 1,
-                alternativeQuantities: [
+                quantities: [
                   {
                     quantity: {
                       type: "fixed",

--- a/test/recipe_parsing.test.ts
+++ b/test/recipe_parsing.test.ts
@@ -53,13 +53,11 @@ describe("parse function", () => {
           name: "eggs",
           quantities: [
             {
-              groupQuantity: {
-                quantity: {
-                  type: "fixed",
-                  value: { type: "decimal", decimal: 3 },
-                },
-                unit: undefined,
+              quantity: {
+                type: "fixed",
+                value: { type: "decimal", decimal: 3 },
               },
+              unit: undefined,
             },
           ],
           usedAsPrimary: true,
@@ -99,13 +97,11 @@ describe("parse function", () => {
           name: "butter",
           quantities: [
             {
-              groupQuantity: {
-                quantity: {
-                  type: "fixed",
-                  value: { type: "decimal", decimal: 30 },
-                },
-                unit: "g",
+              quantity: {
+                type: "fixed",
+                value: { type: "decimal", decimal: 30 },
               },
+              unit: "g",
             },
           ],
           usedAsPrimary: true,
@@ -145,13 +141,11 @@ describe("parse function", () => {
           name: "pizza dough",
           quantities: [
             {
-              groupQuantity: {
-                quantity: {
-                  type: "fixed",
-                  value: { type: "decimal", decimal: 1 },
-                },
-                unit: undefined,
+              quantity: {
+                type: "fixed",
+                value: { type: "decimal", decimal: 1 },
               },
+              unit: undefined,
             },
           ],
           flags: ["recipe"],
@@ -195,13 +189,11 @@ describe("parse function", () => {
           name: "pizza dough",
           quantities: [
             {
-              groupQuantity: {
-                quantity: {
-                  type: "fixed",
-                  value: { type: "decimal", decimal: 1 },
-                },
-                unit: undefined,
+              quantity: {
+                type: "fixed",
+                value: { type: "decimal", decimal: 1 },
               },
+              unit: undefined,
             },
           ],
           flags: ["recipe"],
@@ -246,13 +238,11 @@ describe("parse function", () => {
         name: "wheat flour",
         quantities: [
           {
-            groupQuantity: {
-              quantity: {
-                type: "fixed",
-                value: { type: "decimal", decimal: 100 },
-              },
-              unit: "g",
+            quantity: {
+              type: "fixed",
+              value: { type: "decimal", decimal: 100 },
             },
+            unit: "g",
           },
         ],
         preparation: "sifted",
@@ -262,13 +252,11 @@ describe("parse function", () => {
         name: "eggs",
         quantities: [
           {
-            groupQuantity: {
-              quantity: {
-                type: "fixed",
-                value: { type: "decimal", decimal: 2 },
-              },
-              unit: undefined,
+            quantity: {
+              type: "fixed",
+              value: { type: "decimal", decimal: 2 },
             },
+            unit: undefined,
           },
         ],
         preparation: "large, beaten",
@@ -394,13 +382,11 @@ describe("parse function", () => {
           name: "flour tipo 00",
           quantities: [
             {
-              groupQuantity: {
-                quantity: {
-                  type: "fixed",
-                  value: { type: "decimal", decimal: 150 },
-                },
-                unit: "g",
+              quantity: {
+                type: "fixed",
+                value: { type: "decimal", decimal: 150 },
               },
+              unit: "g",
             },
           ],
           usedAsPrimary: true,
@@ -409,13 +395,11 @@ describe("parse function", () => {
           name: "water",
           quantities: [
             {
-              groupQuantity: {
-                quantity: {
-                  type: "fixed",
-                  value: { type: "decimal", decimal: 300 },
-                },
-                unit: "mL",
+              quantity: {
+                type: "fixed",
+                value: { type: "decimal", decimal: 300 },
               },
+              unit: "mL",
             },
           ],
           usedAsPrimary: true,
@@ -437,13 +421,11 @@ describe("parse function", () => {
         name: "flour",
         quantities: [
           {
-            groupQuantity: {
-              quantity: {
-                type: "fixed",
-                value: { type: "decimal", decimal: 150 },
-              },
-              unit: "g",
+            quantity: {
+              type: "fixed",
+              value: { type: "decimal", decimal: 150 },
             },
+            unit: "g",
           },
         ],
         usedAsPrimary: true,
@@ -536,13 +518,11 @@ describe("parse function", () => {
         name: "flour",
         quantities: [
           {
-            groupQuantity: {
-              quantity: {
-                type: "fixed",
-                value: { type: "decimal", decimal: 100 },
-              },
-              unit: "g",
+            quantity: {
+              type: "fixed",
+              value: { type: "decimal", decimal: 100 },
             },
+            unit: "g",
           },
         ],
         usedAsPrimary: true,
@@ -551,13 +531,11 @@ describe("parse function", () => {
         name: "flour",
         quantities: [
           {
-            groupQuantity: {
-              quantity: {
-                type: "fixed",
-                value: { type: "decimal", decimal: 50 },
-              },
-              unit: "g",
+            quantity: {
+              type: "fixed",
+              value: { type: "decimal", decimal: 50 },
             },
+            unit: "g",
           },
         ],
         usedAsPrimary: true,
@@ -572,16 +550,14 @@ describe("parse function", () => {
           preparation: "boiled",
           quantities: [
             {
-              groupQuantity: {
-                quantity: {
-                  type: "fixed",
-                  value: {
-                    type: "decimal",
-                    decimal: 2,
-                  },
+              quantity: {
+                type: "fixed",
+                value: {
+                  type: "decimal",
+                  decimal: 2,
                 },
-                unit: undefined,
               },
+              unit: undefined,
             },
           ],
           usedAsPrimary: true,
@@ -649,13 +625,11 @@ describe("parse function", () => {
         name: "Sugar", // Note: original casing is preserved
         quantities: [
           {
-            groupQuantity: {
-              quantity: {
-                type: "fixed",
-                value: { type: "decimal", decimal: 150 },
-              },
-              unit: "g",
+            quantity: {
+              type: "fixed",
+              value: { type: "decimal", decimal: 150 },
             },
+            unit: "g",
           },
         ],
         usedAsPrimary: true,
@@ -673,13 +647,11 @@ describe("parse function", () => {
         name: "sugar",
         quantities: [
           {
-            groupQuantity: {
-              quantity: {
-                type: "fixed",
-                value: { type: "decimal", decimal: 1.5 },
-              },
-              unit: "kg",
+            quantity: {
+              type: "fixed",
+              value: { type: "decimal", decimal: 1.5 },
             },
+            unit: "kg",
           },
         ],
         usedAsPrimary: true,
@@ -697,13 +669,11 @@ describe("parse function", () => {
       expect(butter.name).toBe("butter");
       expect(butter.quantities).toEqual([
         {
-          groupQuantity: {
-            quantity: {
-              type: "fixed",
-              value: { type: "decimal", decimal: 0.704 },
-            },
-            unit: "kg",
+          quantity: {
+            type: "fixed",
+            value: { type: "decimal", decimal: 0.704 },
           },
+          unit: "kg",
         },
       ]);
       // TODO: 700g would be more elegant
@@ -734,22 +704,18 @@ describe("parse function", () => {
         name: "water",
         quantities: [
           {
-            groupQuantity: {
-              quantity: {
-                type: "fixed",
-                value: { type: "decimal", decimal: 1 },
-              },
-              unit: "l",
+            quantity: {
+              type: "fixed",
+              value: { type: "decimal", decimal: 1 },
             },
+            unit: "l",
           },
           {
-            groupQuantity: {
-              quantity: {
-                type: "fixed",
-                value: { type: "decimal", decimal: 1 },
-              },
-              unit: "kg",
+            quantity: {
+              type: "fixed",
+              value: { type: "decimal", decimal: 1 },
             },
+            unit: "kg",
           },
         ],
         usedAsPrimary: true,
@@ -939,13 +905,11 @@ Another step.
           name: "pizza dough",
           quantities: [
             {
-              groupQuantity: {
-                quantity: {
-                  type: "fixed",
-                  value: { type: "decimal", decimal: 1 },
-                },
-                unit: undefined,
+              quantity: {
+                type: "fixed",
+                value: { type: "decimal", decimal: 1 },
               },
+              unit: undefined,
             },
           ],
           flags: ["recipe"],
@@ -992,13 +956,11 @@ Another step.
           name: "pizza dough",
           quantities: [
             {
-              groupQuantity: {
-                quantity: {
-                  type: "fixed",
-                  value: { type: "decimal", decimal: 1 },
-                },
-                unit: undefined,
+              quantity: {
+                type: "fixed",
+                value: { type: "decimal", decimal: 1 },
               },
+              unit: undefined,
             },
           ],
           flags: ["recipe"],
@@ -1044,13 +1006,11 @@ Another step.
         name: "wheat flour",
         quantities: [
           {
-            groupQuantity: {
-              quantity: {
-                type: "fixed",
-                value: { type: "decimal", decimal: 100 },
-              },
-              unit: "g",
+            quantity: {
+              type: "fixed",
+              value: { type: "decimal", decimal: 100 },
             },
+            unit: "g",
           },
         ],
         preparation: "sifted",
@@ -1061,13 +1021,11 @@ Another step.
         name: "eggs",
         quantities: [
           {
-            groupQuantity: {
-              quantity: {
-                type: "fixed",
-                value: { type: "decimal", decimal: 2 },
-              },
-              unit: undefined,
+            quantity: {
+              type: "fixed",
+              value: { type: "decimal", decimal: 2 },
             },
+            unit: undefined,
           },
         ],
         preparation: "large, beaten",
@@ -1198,22 +1156,18 @@ Another step.
           name: "flour tipo 00",
           quantities: [
             {
-              groupQuantity: {
-                quantity: {
-                  type: "fixed",
-                  value: { type: "decimal", decimal: 100 },
-                },
-                unit: "g",
+              quantity: {
+                type: "fixed",
+                value: { type: "decimal", decimal: 100 },
               },
+              unit: "g",
             },
             {
-              groupQuantity: {
-                quantity: {
-                  type: "fixed",
-                  value: { type: "decimal", decimal: 100 },
-                },
-                unit: "g",
+              quantity: {
+                type: "fixed",
+                value: { type: "decimal", decimal: 100 },
               },
+              unit: "g",
               alternatives: [
                 {
                   index: 1,
@@ -1249,13 +1203,11 @@ Another step.
         name: "milk",
         quantities: [
           {
-            groupQuantity: {
-              quantity: {
-                type: "fixed",
-                value: { type: "decimal", decimal: 200 },
-              },
-              unit: "ml",
+            quantity: {
+              type: "fixed",
+              value: { type: "decimal", decimal: 200 },
             },
+            unit: "ml",
             alternatives: [
               {
                 index: 1,
@@ -1388,13 +1340,11 @@ Another step.
         name: "milk",
         quantities: [
           {
-            groupQuantity: {
-              quantity: {
-                type: "fixed",
-                value: { type: "decimal", decimal: 200 },
-              },
-              unit: "ml",
+            quantity: {
+              type: "fixed",
+              value: { type: "decimal", decimal: 200 },
             },
+            unit: "ml",
             alternatives: [
               {
                 index: 1,
@@ -1498,13 +1448,11 @@ Another step.
         name: "sea salt",
         quantities: [
           {
-            groupQuantity: {
-              quantity: {
-                type: "fixed",
-                value: { type: "text", text: "some" },
-              },
-              unit: undefined,
+            quantity: {
+              type: "fixed",
+              value: { type: "text", text: "some" },
             },
+            unit: undefined,
             alternatives: [
               {
                 index: 1,
@@ -1535,13 +1483,11 @@ Another step.
         name: "sugar",
         quantities: [
           {
-            groupQuantity: {
-              quantity: {
-                type: "fixed",
-                value: { type: "decimal", decimal: 100 },
-              },
-              unit: "g",
+            quantity: {
+              type: "fixed",
+              value: { type: "decimal", decimal: 100 },
             },
+            unit: "g",
             alternatives: [
               {
                 index: 1,
@@ -1558,13 +1504,11 @@ Another step.
             ],
           },
           {
-            groupQuantity: {
-              quantity: {
-                type: "fixed",
-                value: { type: "decimal", decimal: 50 },
-              },
-              unit: "g",
+            quantity: {
+              type: "fixed",
+              value: { type: "decimal", decimal: 50 },
             },
+            unit: "g",
             alternatives: [
               {
                 index: 2,
@@ -1597,13 +1541,11 @@ Another step.
         name: "sugar",
         quantities: [
           {
-            groupQuantity: {
-              quantity: {
-                type: "fixed",
-                value: { type: "decimal", decimal: 100 },
-              },
-              unit: "g",
+            quantity: {
+              type: "fixed",
+              value: { type: "decimal", decimal: 100 },
             },
+            unit: "g",
             alternatives: [
               {
                 index: 1,
@@ -1620,13 +1562,11 @@ Another step.
             ],
           },
           {
-            groupQuantity: {
-              quantity: {
-                type: "fixed",
-                value: { type: "decimal", decimal: 50 },
-              },
-              unit: "g",
+            quantity: {
+              type: "fixed",
+              value: { type: "decimal", decimal: 50 },
             },
+            unit: "g",
             alternatives: [
               {
                 index: 2,
@@ -1689,13 +1629,11 @@ Another step.
         name: "aubergine",
         quantities: [
           {
-            groupQuantity: {
-              quantity: {
-                type: "fixed",
-                value: { type: "decimal", decimal: 2 },
-              },
-              unit: undefined,
+            quantity: {
+              type: "fixed",
+              value: { type: "decimal", decimal: 2 },
             },
+            unit: undefined,
             alternatives: [
               {
                 index: 1,
@@ -1738,13 +1676,11 @@ Another step.
         name: "sugar",
         quantities: [
           {
-            groupQuantity: {
-              quantity: {
-                type: "fixed",
-                value: { type: "decimal", decimal: 150 },
-              },
-              unit: "g",
+            quantity: {
+              type: "fixed",
+              value: { type: "decimal", decimal: 150 },
             },
+            unit: "g",
             alternatives: [
               {
                 index: 1,
@@ -1789,29 +1725,27 @@ Another step.
         name: "flour",
         quantities: [
           {
-            groupQuantity: {
-              quantity: {
-                type: "fixed",
-                value: { type: "decimal", decimal: 1 },
-              },
-              unit: "bag",
-              equivalents: [
-                {
-                  quantity: {
-                    type: "fixed",
-                    value: { type: "decimal", decimal: 0.22 },
-                  },
-                  unit: "lb",
-                },
-                {
-                  quantity: {
-                    type: "fixed",
-                    value: { type: "decimal", decimal: 3.5 },
-                  },
-                  unit: "oz",
-                },
-              ],
+            quantity: {
+              type: "fixed",
+              value: { type: "decimal", decimal: 1 },
             },
+            unit: "bag",
+            equivalents: [
+              {
+                quantity: {
+                  type: "fixed",
+                  value: { type: "decimal", decimal: 0.22 },
+                },
+                unit: "lb",
+              },
+              {
+                quantity: {
+                  type: "fixed",
+                  value: { type: "decimal", decimal: 3.5 },
+                },
+                unit: "oz",
+              },
+            ],
           },
         ],
         usedAsPrimary: true,
@@ -1862,22 +1796,20 @@ Another step.
         name: "flour",
         quantities: [
           {
-            groupQuantity: {
-              quantity: {
-                type: "fixed",
-                value: { type: "decimal", decimal: 1 },
-              },
-              unit: "bag",
-              equivalents: [
-                {
-                  quantity: {
-                    type: "fixed",
-                    value: { type: "decimal", decimal: 0.22 },
-                  },
-                  unit: "lb",
-                },
-              ],
+            quantity: {
+              type: "fixed",
+              value: { type: "decimal", decimal: 1 },
             },
+            unit: "bag",
+            equivalents: [
+              {
+                quantity: {
+                  type: "fixed",
+                  value: { type: "decimal", decimal: 0.22 },
+                },
+                unit: "lb",
+              },
+            ],
             alternatives: [
               {
                 index: 1,
@@ -1975,22 +1907,20 @@ Another step.
         name: "wheat flour",
         quantities: [
           {
-            groupQuantity: {
-              quantity: {
-                type: "fixed",
-                value: { type: "decimal", decimal: 1 },
-              },
-              unit: "bag",
-              equivalents: [
-                {
-                  quantity: {
-                    type: "fixed",
-                    value: { type: "decimal", decimal: 0.22 },
-                  },
-                  unit: "lb",
-                },
-              ],
+            quantity: {
+              type: "fixed",
+              value: { type: "decimal", decimal: 1 },
             },
+            unit: "bag",
+            equivalents: [
+              {
+                quantity: {
+                  type: "fixed",
+                  value: { type: "decimal", decimal: 0.22 },
+                },
+                unit: "lb",
+              },
+            ],
             alternatives: [
               {
                 index: 1,
@@ -2109,22 +2039,20 @@ Another step.
         name: "all-purpose flour",
         quantities: [
           {
-            groupQuantity: {
-              quantity: {
-                type: "fixed",
-                value: { type: "decimal", decimal: 2 },
-              },
-              unit: "bag",
-              equivalents: [
-                {
-                  quantity: {
-                    type: "fixed",
-                    value: { type: "decimal", decimal: 0.5 },
-                  },
-                  unit: "lb",
-                },
-              ],
+            quantity: {
+              type: "fixed",
+              value: { type: "decimal", decimal: 2 },
             },
+            unit: "bag",
+            equivalents: [
+              {
+                quantity: {
+                  type: "fixed",
+                  value: { type: "decimal", decimal: 0.5 },
+                },
+                unit: "lb",
+              },
+            ],
             alternatives: [
               {
                 index: 1,
@@ -2150,31 +2078,27 @@ Another step.
             ],
           },
           {
-            groupQuantity: {
-              quantity: {
-                type: "fixed",
-                value: { type: "decimal", decimal: 1 },
-              },
-              unit: "bag",
-              equivalents: [
-                {
-                  quantity: {
-                    type: "fixed",
-                    value: { type: "decimal", decimal: 0.25 },
-                  },
-                  unit: "lb",
-                },
-              ],
+            quantity: {
+              type: "fixed",
+              value: { type: "decimal", decimal: 1 },
             },
+            unit: "bag",
+            equivalents: [
+              {
+                quantity: {
+                  type: "fixed",
+                  value: { type: "decimal", decimal: 0.25 },
+                },
+                unit: "lb",
+              },
+            ],
           },
           {
-            groupQuantity: {
-              quantity: {
-                type: "fixed",
-                value: { type: "decimal", decimal: 1 },
-              },
-              unit: "pinch",
+            quantity: {
+              type: "fixed",
+              value: { type: "decimal", decimal: 1 },
             },
+            unit: "pinch",
             alternatives: [
               {
                 index: 1,

--- a/test/recipe_scaling.test.ts
+++ b/test/recipe_scaling.test.ts
@@ -361,7 +361,7 @@ serves: 2, some
         alternatives: [
           {
             index: 1,
-            alternativeQuantities: [
+            quantities: [
               {
                 quantity: {
                   type: "fixed",
@@ -373,7 +373,7 @@ serves: 2, some
           },
           {
             index: 2,
-            alternativeQuantities: [
+            quantities: [
               {
                 quantity: {
                   type: "fixed",

--- a/test/recipe_scaling.test.ts
+++ b/test/recipe_scaling.test.ts
@@ -21,36 +21,30 @@ describe("scaleTo", () => {
     expect(scaledRecipe.ingredients.length).toBe(4);
     expect(scaledRecipe.ingredients[0]!.quantities).toEqual([
       {
-        groupQuantity: {
-          quantity: {
-            type: "fixed",
-            value: { type: "decimal", decimal: 200 },
-          },
-          unit: "g",
+        quantity: {
+          type: "fixed",
+          value: { type: "decimal", decimal: 200 },
         },
+        unit: "g",
       },
     ]);
     expect(scaledRecipe.ingredients[1]!.quantities).toEqual([
       {
-        groupQuantity: {
-          quantity: {
-            type: "fixed",
-            value: { type: "decimal", decimal: 1 },
-          },
-          unit: "tsp",
+        quantity: {
+          type: "fixed",
+          value: { type: "decimal", decimal: 1 },
         },
+        unit: "tsp",
       },
     ]);
     expect(scaledRecipe.ingredients[2]!.quantities).toEqual([
       {
-        groupQuantity: {
-          quantity: {
-            type: "range",
-            min: { type: "decimal", decimal: 4 },
-            max: { type: "decimal", decimal: 6 },
-          },
-          unit: undefined,
+        quantity: {
+          type: "range",
+          min: { type: "decimal", decimal: 4 },
+          max: { type: "decimal", decimal: 6 },
         },
+        unit: undefined,
       },
     ]);
     expect(scaledRecipe.ingredients[3]!.quantities).toBeUndefined();
@@ -61,36 +55,30 @@ describe("scaleTo", () => {
     expect(scaledRecipe.ingredients.length).toBe(4);
     expect(scaledRecipe.ingredients[0]!.quantities).toEqual([
       {
-        groupQuantity: {
-          quantity: {
-            type: "fixed",
-            value: { type: "decimal", decimal: 50 },
-          },
-          unit: "g",
+        quantity: {
+          type: "fixed",
+          value: { type: "decimal", decimal: 50 },
         },
+        unit: "g",
       },
     ]);
     expect(scaledRecipe.ingredients[1]!.quantities).toEqual([
       {
-        groupQuantity: {
-          quantity: {
-            type: "fixed",
-            value: { type: "fraction", num: 1, den: 4 },
-          },
-          unit: "tsp",
+        quantity: {
+          type: "fixed",
+          value: { type: "fraction", num: 1, den: 4 },
         },
+        unit: "tsp",
       },
     ]);
     expect(scaledRecipe.ingredients[2]!.quantities).toEqual([
       {
-        groupQuantity: {
-          quantity: {
-            type: "range",
-            min: { type: "decimal", decimal: 1 },
-            max: { type: "decimal", decimal: 1.5 },
-          },
-          unit: undefined,
+        quantity: {
+          type: "range",
+          min: { type: "decimal", decimal: 1 },
+          max: { type: "decimal", decimal: 1.5 },
         },
+        unit: undefined,
       },
     ]);
   });
@@ -132,13 +120,11 @@ describe("scaleTo", () => {
     const water = scaledRecipe.ingredients[0]!.quantities;
     if (!water) throw new Error("No quantities found for water ingredient");
     expect(water[0]).toEqual({
-      groupQuantity: {
-        quantity: {
-          type: "fixed",
-          value: { type: "decimal", decimal: 4 },
-        },
-        unit: "L",
+      quantity: {
+        type: "fixed",
+        value: { type: "decimal", decimal: 4 },
       },
+      unit: "L",
     });
   });
 
@@ -155,13 +141,11 @@ describe("scaleTo", () => {
     expect(scaledRecipe.ingredients.length).toBe(1);
     expect(scaledRecipe.ingredients[0]!.quantities).toEqual([
       {
-        groupQuantity: {
-          quantity: {
-            type: "fixed",
-            value: { type: "decimal", decimal: 2 },
-          },
-          unit: "L",
+        quantity: {
+          type: "fixed",
+          value: { type: "decimal", decimal: 2 },
         },
+        unit: "L",
       },
     ]);
     expect(scaledRecipe.servings).toBe(4);
@@ -176,13 +160,11 @@ servings: 3
     const scaledRecipe = recipe.scaleTo(2);
     expect(scaledRecipe.ingredients[0]!.quantities).toEqual([
       {
-        groupQuantity: {
-          quantity: {
-            type: "fixed",
-            value: { type: "decimal", decimal: 4 },
-          },
-          unit: undefined,
+        quantity: {
+          type: "fixed",
+          value: { type: "decimal", decimal: 4 },
         },
+        unit: undefined,
       },
     ]);
   });
@@ -196,36 +178,30 @@ describe("scaleBy", () => {
     expect(scaledRecipe.ingredients.length).toBe(4);
     expect(scaledRecipe.ingredients[0]!.quantities).toEqual([
       {
-        groupQuantity: {
-          quantity: {
-            type: "fixed",
-            value: { type: "decimal", decimal: 200 },
-          },
-          unit: "g",
+        quantity: {
+          type: "fixed",
+          value: { type: "decimal", decimal: 200 },
         },
+        unit: "g",
       },
     ]);
     expect(scaledRecipe.ingredients[1]!.quantities).toEqual([
       {
-        groupQuantity: {
-          quantity: {
-            type: "fixed",
-            value: { type: "decimal", decimal: 1 },
-          },
-          unit: "tsp",
+        quantity: {
+          type: "fixed",
+          value: { type: "decimal", decimal: 1 },
         },
+        unit: "tsp",
       },
     ]);
     expect(scaledRecipe.ingredients[2]!.quantities).toEqual([
       {
-        groupQuantity: {
-          quantity: {
-            type: "range",
-            min: { type: "decimal", decimal: 4 },
-            max: { type: "decimal", decimal: 6 },
-          },
-          unit: undefined,
+        quantity: {
+          type: "range",
+          min: { type: "decimal", decimal: 4 },
+          max: { type: "decimal", decimal: 6 },
         },
+        unit: undefined,
       },
     ]);
     expect(scaledRecipe.ingredients[3]!.quantities).toBeUndefined();
@@ -236,36 +212,30 @@ describe("scaleBy", () => {
     expect(scaledRecipe.ingredients.length).toBe(4);
     expect(scaledRecipe.ingredients[0]!.quantities).toEqual([
       {
-        groupQuantity: {
-          quantity: {
-            type: "fixed",
-            value: { type: "decimal", decimal: 50 },
-          },
-          unit: "g",
+        quantity: {
+          type: "fixed",
+          value: { type: "decimal", decimal: 50 },
         },
+        unit: "g",
       },
     ]);
     expect(scaledRecipe.ingredients[1]!.quantities).toEqual([
       {
-        groupQuantity: {
-          quantity: {
-            type: "fixed",
-            value: { type: "fraction", num: 1, den: 4 },
-          },
-          unit: "tsp",
+        quantity: {
+          type: "fixed",
+          value: { type: "fraction", num: 1, den: 4 },
         },
+        unit: "tsp",
       },
     ]);
     expect(scaledRecipe.ingredients[2]!.quantities).toEqual([
       {
-        groupQuantity: {
-          quantity: {
-            type: "range",
-            min: { type: "decimal", decimal: 1 },
-            max: { type: "decimal", decimal: 1.5 },
-          },
-          unit: undefined,
+        quantity: {
+          type: "range",
+          min: { type: "decimal", decimal: 1 },
+          max: { type: "decimal", decimal: 1.5 },
         },
+        unit: undefined,
       },
     ]);
   });
@@ -291,13 +261,11 @@ describe("scaleBy", () => {
     const water = scaledRecipe.ingredients[0]!.quantities;
     if (!water) throw new Error("No quantities found for water ingredient");
     expect(water[0]).toEqual({
-      groupQuantity: {
-        quantity: {
-          type: "fixed",
-          value: { type: "decimal", decimal: 2 },
-        },
-        unit: "L",
+      quantity: {
+        type: "fixed",
+        value: { type: "decimal", decimal: 2 },
       },
+      unit: "L",
     });
   });
 
@@ -314,13 +282,11 @@ describe("scaleBy", () => {
     expect(scaledRecipe.ingredients.length).toBe(1);
     expect(scaledRecipe.ingredients[0]!.quantities).toEqual([
       {
-        groupQuantity: {
-          quantity: {
-            type: "fixed",
-            value: { type: "decimal", decimal: 2 },
-          },
-          unit: "L",
+        quantity: {
+          type: "fixed",
+          value: { type: "decimal", decimal: 2 },
         },
+        unit: "L",
       },
     ]);
     expect(scaledRecipe.servings).toBe(4);
@@ -351,13 +317,11 @@ serves: 2, some
       | IngredientQuantityAndGroup
     )[] = [
       {
-        groupQuantity: {
-          quantity: {
-            type: "fixed",
-            value: { type: "decimal", decimal: 400 },
-          },
-          unit: "ml",
+        quantity: {
+          type: "fixed",
+          value: { type: "decimal", decimal: 400 },
         },
+        unit: "ml",
         alternatives: [
           {
             index: 1,
@@ -450,29 +414,27 @@ Use @sugar{100%g|0.5%cups|3.5%oz} in the mix.
       | IngredientQuantityAndGroup
     )[] = [
       {
-        groupQuantity: {
-          quantity: {
-            type: "fixed",
-            value: { type: "decimal", decimal: 200 },
-          },
-          unit: "g",
-          equivalents: [
-            {
-              quantity: {
-                type: "fixed",
-                value: { type: "decimal", decimal: 1 },
-              },
-              unit: "cups",
-            },
-            {
-              quantity: {
-                type: "fixed",
-                value: { type: "decimal", decimal: 7 },
-              },
-              unit: "oz",
-            },
-          ],
+        quantity: {
+          type: "fixed",
+          value: { type: "decimal", decimal: 200 },
         },
+        unit: "g",
+        equivalents: [
+          {
+            quantity: {
+              type: "fixed",
+              value: { type: "decimal", decimal: 1 },
+            },
+            unit: "cups",
+          },
+          {
+            quantity: {
+              type: "fixed",
+              value: { type: "decimal", decimal: 7 },
+            },
+            unit: "oz",
+          },
+        ],
       },
     ];
     expect(scaledRecipe.ingredients[0]!.quantities).toEqual(
@@ -529,21 +491,19 @@ Use @sugar{100%g|a cup} in the mix.
       | IngredientQuantityAndGroup
     )[] = [
       {
-        groupQuantity: {
-          quantity: {
-            type: "fixed",
-            value: { type: "decimal", decimal: 200 },
-          },
-          unit: "g",
-          equivalents: [
-            {
-              quantity: {
-                type: "fixed",
-                value: { type: "text", text: "a cup" },
-              },
-            },
-          ],
+        quantity: {
+          type: "fixed",
+          value: { type: "decimal", decimal: 200 },
         },
+        unit: "g",
+        equivalents: [
+          {
+            quantity: {
+              type: "fixed",
+              value: { type: "text", text: "a cup" },
+            },
+          },
+        ],
       },
     ];
     expect(scaledRecipe.ingredients[0]!.quantities).toEqual(
@@ -556,24 +516,20 @@ Use @sugar{100%g|a cup} in the mix.
     const scaledRecipe = recipe.scaleBy(2);
     expect(scaledRecipe.ingredients[0]!.quantities).toEqual([
       {
-        groupQuantity: {
-          quantity: {
-            type: "fixed",
-            value: { type: "decimal", decimal: 100 },
-          },
-          unit: "g",
+        quantity: {
+          type: "fixed",
+          value: { type: "decimal", decimal: 100 },
         },
+        unit: "g",
       },
     ]);
     expect(scaledRecipe.ingredients[1]!.quantities).toEqual([
       {
-        groupQuantity: {
-          quantity: {
-            type: "fixed",
-            value: { type: "decimal", decimal: 10 },
-          },
-          unit: "g",
+        quantity: {
+          type: "fixed",
+          value: { type: "decimal", decimal: 10 },
         },
+        unit: "g",
       },
     ]);
   });


### PR DESCRIPTION
# Description

Refactored the ingredient quantity data structure to simplify and improve consistency. This change replaces the nested `groupQuantity` property with direct properties on the `IngredientQuantityGroup` interface, making it extend `QuantityWithPlainUnit`. Similarly, renamed `alternativeQuantities` to `quantities` in the `AlternativeIngredientRef` interface for better clarity.

The PR updates all component templates to use the new structure, including proper property access in `IngredientItem.vue`, `QuantityWithEquivalents.vue`, and `StepContent.vue`. The type guard `isSimpleGroup` now checks for the presence of a `quantity` property instead of `groupQuantity`.

**Related Issue:** N/A

## Type of change

- [x] Enhancement (refactoring, style or performance improvement)

## Breaking Changes

This change flattens the ingredient quantity data structure:
- `IngredientQuantityGroup` now extends `QuantityWithPlainUnit` instead of containing it
- `groupQuantity` property is removed, with its properties moved to the parent object
- `alternativeQuantities` is renamed to `quantities` in `AlternativeIngredientRef`

# How Has This Been Tested?

- [x] Existing unit tests have been updated to use the new structure
- [x] All tests pass with the refactored code
- [x] Manual testing of the components in the playground

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have run `pnpm lint` and my changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes