### PR TITLE
feat(playground): add GitHub and docs links to header

### DIFF
--- a/playground/app/pages/index.vue
+++ b/playground/app/pages/index.vue
@@ -59,13 +59,31 @@ const parsedRecipe = computed(() => {
   <div class="h-screen w-full p-4">
     <div class="mb-2 flex justify-between">
       <div class="flex flex-col gap-1">
-        <h1 class="text-2xl font-bold md:text-3xl">
+        <h1 class="text-xl font-bold md:text-3xl">
           <b>@tmlmt/cooklang-parser</b>
         </h1>
         <div class="text-lg font-semibold">Playground</div>
       </div>
       <div class="flex flex-col items-end justify-around gap-1">
-        <UColorModeButton />
+        <div class="flex items-center">
+          <UButton
+            to="https://github.com/tmlmt/cooklang-parser"
+            target="_blank"
+            class="hover:bg-elevated active:bg-accented h-8 w-6 bg-transparent md:w-7 dark:bg-neutral-900"
+            ><UIcon
+              name="mdi:github"
+              class="dark:focus:bg-royal-800 size-5 shrink-0 bg-gray-700 dark:bg-white"
+          /></UButton>
+          <UButton
+            to="https://cooklang-parser.tmlmt.com/v3"
+            target="_blank"
+            class="hover:bg-elevated active:bg-accented h-8 w-7 bg-transparent md:w-8 dark:bg-neutral-900"
+            ><UIcon
+              name="material-symbols:docs"
+              class="size-5 shrink-0 bg-gray-700 dark:bg-white"
+          /></UButton>
+          <UColorModeButton />
+        </div>
         <div class="mb-1 text-xs md:text-sm">{{ fullVersion }}</div>
       </div>
     </div>


### PR DESCRIPTION
# Description

Added GitHub and documentation links to the playground header. This enhances navigation by providing direct access to the repository and documentation from the playground interface. Also adjusted the title size for better visual hierarchy.

**Related Issue:** N/A

## Type of change

- [x] Enhancement (refactoring, style or performance improvement)
- [x] Documentation change (improvement to the Vitepress documentation or playground)

# How Has This Been Tested?

- [x] Verified links open correctly in new tabs
- [x] Confirmed proper icon rendering in both light and dark modes
- [x] Tested responsive behavior on different screen sizes

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have run `pnpm lint` and my changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules