### PR TITLE
chore(playground): remove passing of invalid prop in IngredientItem

### DIFF
--- a/playground/app/components/recipe/IngredientItem.vue
+++ b/playground/app/components/recipe/IngredientItem.vue
@@ -159,7 +159,6 @@ const displayMode = computed<DisplayMode>(() => {
               <RecipeSingleQuantity
                 :quantity="eq.quantity"
                 :unit="eq.unit"
-                :equivalents="eq.equivalents"
               /> </template
             >)
           </template>
@@ -230,7 +229,6 @@ const displayMode = computed<DisplayMode>(() => {
             <RecipeSingleQuantity
               :quantity="eq.quantity"
               :unit="eq.unit"
-              :equivalents="eq.equivalents"
             /> </template
           >)
         </template>
@@ -269,7 +267,6 @@ const displayMode = computed<DisplayMode>(() => {
                   <RecipeSingleQuantity
                     :quantity="eq.quantity"
                     :unit="eq.unit"
-                    :equivalents="eq.equivalents"
                   /> </template
                 >)
               </template>


### PR DESCRIPTION
# Description

Removed the `:equivalents` prop from `RecipeSingleQuantity` component instances in the `IngredientItem.vue` file. This prop was being passed but appears to be unused or no longer needed in the component.

**Related Issue:** N/A

## Type of change

- [x] Enhancement (refactoring, style or performance improvement)

# How Has This Been Tested?

- [x] Verified that recipe ingredient quantities still display correctly
- [x] Checked that no console errors appear related to missing props

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have run `pnpm lint` and my changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules