### PR TITLE
chore(alternatives): remove useless variable expansion

### DIFF
--- a/src/quantities/alternatives.ts
+++ b/src/quantities/alternatives.ts
@@ -47,7 +47,6 @@ export function getEquivalentUnitsLists(
 
   const unitLists: QuantityWithUnitDef[][] = [];
   const normalizeOrGroup = (og: FlatOrGroup<QuantityWithExtendedUnit>) => ({
-    ...og,
     or: og.or.map((q) => ({
       ...q,
       unit: resolveUnit(q.unit?.name, q.unit?.integerProtected),


### PR DESCRIPTION
# Description

Removed unnecessary object spread operator in the `normalizeOrGroup` function within `getEquivalentUnitsLists`. The spread operator was redundant as we're already creating a new object with the mapped `or` property.

**Related Issue:** N/A

## Type of change

- [x] Enhancement (refactoring, style or performance improvement)

# How Has This Been Tested?

- [x] Verified that the functionality remains unchanged
- [x] Confirmed that unit tests still pass

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have run `pnpm lint` and my changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes